### PR TITLE
[Step 4] 동시성 이슈 

### DIFF
--- a/src/main/kotlin/kr/com/hhp/lectureapiserver/lecture/application/LectureService.kt
+++ b/src/main/kotlin/kr/com/hhp/lectureapiserver/lecture/application/LectureService.kt
@@ -7,8 +7,6 @@ import kr.com.hhp.lectureapiserver.lecture.application.exception.LectureDuplicat
 import kr.com.hhp.lectureapiserver.lecture.application.exception.LectureNotFoundException
 import kr.com.hhp.lectureapiserver.lecture.infra.entity.LectureEntity
 import kr.com.hhp.lectureapiserver.user.application.UserService
-import kr.com.hhp.lectureapiserver.user.application.exception.UserDuplicateException
-import kr.com.hhp.lectureapiserver.user.infra.UserEntity
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -50,8 +48,8 @@ class LectureService(
     }
 
     private fun verifyApplyPreconditions(userId: Long, lectureId: Long) {
+        val lecture = getByLectureIdWithXLock(lectureId)
         userService.getByUserId(userId)
-        val lecture = getByLectureId(lectureId)
 
         val lectureUser = lectureUserService.getNullAbleLectureUser(userId = userId, lectureId = lectureId)
 
@@ -71,6 +69,12 @@ class LectureService(
     @Transactional(readOnly = true)
     fun getByLectureId(lectureId: Long): LectureEntity {
         return lectureRepository.findByLectureId(lectureId)
+            ?: throw LectureNotFoundException("Lecture를 찾을 수 없습니다. lectureId : $lectureId")
+    }
+
+    @Transactional(readOnly = true)
+    fun getByLectureIdWithXLock(lectureId: Long): LectureEntity {
+        return lectureRepository.findByLectureIdWithXLock(lectureId)
             ?: throw LectureNotFoundException("Lecture를 찾을 수 없습니다. lectureId : $lectureId")
     }
 

--- a/src/main/kotlin/kr/com/hhp/lectureapiserver/lecture/domain/LectureRepository.kt
+++ b/src/main/kotlin/kr/com/hhp/lectureapiserver/lecture/domain/LectureRepository.kt
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository
 @Repository
 interface LectureRepository {
     fun findByLectureId(lectureId: Long) : LectureEntity?
+    fun findByLectureIdWithXLock(lectureId: Long) : LectureEntity?
     fun findAllByOrderByLectureIdDesc(pageable: Pageable) : Page<LectureEntity>
     fun save(lectureEntity: LectureEntity): LectureEntity
 }

--- a/src/main/kotlin/kr/com/hhp/lectureapiserver/lecture/infra/jpa/LectureJpaRepository.kt
+++ b/src/main/kotlin/kr/com/hhp/lectureapiserver/lecture/infra/jpa/LectureJpaRepository.kt
@@ -1,15 +1,22 @@
 package kr.com.hhp.lectureapiserver.lecture.infra.jpa
 
+import jakarta.persistence.LockModeType
 import kr.com.hhp.lectureapiserver.lecture.domain.LectureRepository
 import kr.com.hhp.lectureapiserver.lecture.infra.entity.LectureEntity
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
 interface LectureJpaRepository: JpaRepository<LectureEntity, Long>, LectureRepository {
     override fun findByLectureId(lectureId: Long) : LectureEntity?
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE) //LectureId가 동일한 데이터만 비관적 Lock
+    @Query("SELECT lecture FROM LectureEntity as lecture WHERE lecture.lectureId = :lectureId")
+    override fun findByLectureIdWithXLock(lectureId: Long) : LectureEntity?
     override fun findAllByOrderByLectureIdDesc(pageable: Pageable) : Page<LectureEntity>
     override fun save(lectureEntity: LectureEntity): LectureEntity
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,10 +4,12 @@ spring:
       lecture-api-server
 
   datasource:
-    url: jdbc:h2:mem:lecture;NON_KEYWORDS=USER
+    url: jdbc:h2:mem:lecture;NON_KEYWORDS=USER;MODE=MYSQL
     driver-class-name: org.h2.Driver
     username: sa
     password:
+    hikari:
+      maximum-pool-size: 100  # 최대 풀 크기 (기본값 10)
   h2:
     console:
       enabled: true
@@ -17,3 +19,9 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
+
+server:
+  tomcat:
+    threads:
+      max: 200 # 스레드 최대 개수 (기본값 200)
+      min-spare: 10 #활성화 상태로 유지할 최소 쓰레드 개수 (기본값 10)

--- a/src/test/kotlin/kr/com/hhp/lectureapiserver/integration/lecture/application/LectureServiceTest.kt
+++ b/src/test/kotlin/kr/com/hhp/lectureapiserver/integration/lecture/application/LectureServiceTest.kt
@@ -1,0 +1,62 @@
+package kr.com.hhp.lectureapiserver.integration.lecture.application
+
+import kr.com.hhp.lectureapiserver.lecture.application.LectureService
+import kr.com.hhp.lectureapiserver.lecture.application.LectureUserService
+import kr.com.hhp.lectureapiserver.user.application.UserService
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.Semaphore
+import kotlin.test.assertEquals
+
+@SpringBootTest
+class LectureServiceTest {
+
+    @Autowired
+    private lateinit var userService: UserService
+
+    @Autowired
+    private lateinit var lectureService: LectureService
+
+    @Autowired
+    private lateinit var lectureUserService: LectureUserService
+
+    @Test
+    fun `특강 신청 비관적 Lock 테스트`() {
+        // given
+        val lectureId = 1L
+        val numberOfThreads = 50
+        val maxConcurrentThreads = 10
+
+        val executor = Executors.newCachedThreadPool()
+        val latch = CountDownLatch(numberOfThreads)
+        val semaphore = Semaphore(maxConcurrentThreads)
+        val lectureEntity = lectureService.save(lectureId)
+        val capacity = lectureEntity.capacity
+
+        for (i in 1 .. numberOfThreads) {
+            userService.save(i.toLong())
+        }
+
+        //when
+        for (i in 1 ..  numberOfThreads) {
+            executor.submit {
+                semaphore.acquire()
+                try {
+                    lectureService.apply(userId = i.toLong(), lectureId = lectureId)
+                } finally {
+                    semaphore.release()
+                    latch.countDown()
+                }
+            }
+        }
+        latch.await()
+        executor.shutdown()
+
+        val countAllByLectureId = lectureUserService.countAllByLectureId(lectureId)
+
+        assertEquals(capacity.toLong(), countAllByLectureId)
+    }
+}

--- a/src/test/kotlin/kr/com/hhp/lectureapiserver/unit/lecture/application/LectureServiceTest.kt
+++ b/src/test/kotlin/kr/com/hhp/lectureapiserver/unit/lecture/application/LectureServiceTest.kt
@@ -100,7 +100,7 @@ class LectureServiceTest {
             val capacity = 30
             val isSuccessful = true
 
-            given(lectureRepository.findByLectureId(lectureId))
+            given(lectureRepository.findByLectureIdWithXLock(lectureId))
                 .willReturn(LectureEntity(lectureId = lectureId, capacity = capacity))
             given(lectureEnrollmentHistoryService.save(lectureId = lectureId, userId = userId, isSuccessful = isSuccessful))
                 .willReturn(LectureEnrollmentHistoryEntity(lectureId = lectureId, userId = userId, isSuccessful = isSuccessful))
@@ -110,7 +110,7 @@ class LectureServiceTest {
             lectureService.apply(userId, lectureId)
 
             //then
-            then(lectureRepository).should().findByLectureId(lectureId)
+            then(lectureRepository).should().findByLectureIdWithXLock(lectureId)
             then(lectureEnrollmentHistoryService).should().save(lectureId = lectureId, userId = userId, isSuccessful = isSuccessful)
             then(userService).should().getByUserId(userId)
         }
@@ -123,7 +123,7 @@ class LectureServiceTest {
             val capacity = 0
             val isSuccessful = false
 
-            given(lectureRepository.findByLectureId(lectureId))
+            given(lectureRepository.findByLectureIdWithXLock(lectureId))
                 .willReturn(LectureEntity(lectureId = lectureId, capacity = capacity))
 
             given(lectureEnrollmentHistoryService.save(lectureId = lectureId, userId = userId, isSuccessful = isSuccessful))
@@ -137,7 +137,7 @@ class LectureServiceTest {
             }
 
             //then
-            then(lectureRepository).should().findByLectureId(lectureId)
+            then(lectureRepository).should().findByLectureIdWithXLock(lectureId)
             then(lectureEnrollmentHistoryService).should().save(lectureId = lectureId, userId = userId, isSuccessful = isSuccessful)
             then(userService).should().getByUserId(userId)
             assertEquals("정원을 초과하였습니다.", exception.message)
@@ -160,7 +160,7 @@ class LectureServiceTest {
 
             given(userService.getByUserId(userId)).willReturn(UserEntity(userId))
 
-            given(lectureRepository.findByLectureId(lectureId))
+            given(lectureRepository.findByLectureIdWithXLock(lectureId))
                 .willReturn(LectureEntity(lectureId = lectureId, capacity = capacity))
 
             //when
@@ -172,7 +172,7 @@ class LectureServiceTest {
             then(lectureUserService).should().getNullAbleLectureUser(userId = userId, lectureId =  lectureId)
             then(lectureEnrollmentHistoryService).should().save(lectureId = lectureId, userId = userId, isSuccessful = isSuccessful)
             then(userService).should().getByUserId(userId)
-            then(lectureRepository).should().findByLectureId(lectureId)
+            then(lectureRepository).should().findByLectureIdWithXLock(lectureId)
             assertEquals("동일한 특강에 신청완료된 내역이 있습니다. userId : $userId, lectureId : $lectureId", exception.message)
         }
 
@@ -181,9 +181,12 @@ class LectureServiceTest {
             //given
             val userId = 1L
             val lectureId = 1L
+            val capacity = 30
             val isSuccessful = false
             val expectedErrorMessage = "User를 찾을 수 없습니다. userId : $userId"
 
+            given(lectureRepository.findByLectureIdWithXLock(lectureId))
+                .willReturn(LectureEntity(lectureId = lectureId, capacity = capacity))
             given(lectureEnrollmentHistoryService.save(lectureId = lectureId, userId = userId, isSuccessful = isSuccessful))
                 .willReturn(LectureEnrollmentHistoryEntity(lectureId = lectureId, userId = userId, isSuccessful = isSuccessful))
 
@@ -195,6 +198,7 @@ class LectureServiceTest {
             }
 
             //then
+            then(lectureRepository).should().findByLectureIdWithXLock(lectureId)
             then(lectureEnrollmentHistoryService).should().save(lectureId = lectureId, userId = userId, isSuccessful = isSuccessful)
             then(userService).should().getByUserId(userId)
             assertEquals(expectedErrorMessage, exception.message)
@@ -208,12 +212,10 @@ class LectureServiceTest {
             val isSuccessful = false
             val expectedErrorMessage = "Lecture를 찾을 수 없습니다. lectureId : $lectureId"
 
-            given(lectureRepository.findByLectureId(lectureId)).willReturn(null)
+            given(lectureRepository.findByLectureIdWithXLock(lectureId)).willReturn(null)
 
             given(lectureEnrollmentHistoryService.save(lectureId = lectureId, userId = userId, isSuccessful = isSuccessful))
                 .willReturn(LectureEnrollmentHistoryEntity(lectureId = lectureId, userId = userId, isSuccessful = isSuccessful))
-
-            given(userService.getByUserId(userId)).willReturn(UserEntity(userId))
 
             //when
             val exception = assertThrows<LectureNotFoundException> {
@@ -221,9 +223,8 @@ class LectureServiceTest {
             }
 
             //then
-            then(lectureRepository).should().findByLectureId(lectureId)
+            then(lectureRepository).should().findByLectureIdWithXLock(lectureId)
             then(lectureEnrollmentHistoryService).should().save(lectureId = lectureId, userId = userId, isSuccessful = isSuccessful)
-            then(userService).should().getByUserId(userId)
             assertEquals(expectedErrorMessage, exception.message)
         }
 
@@ -281,6 +282,7 @@ class LectureServiceTest {
             val user = lectureService.save(lectureId)
 
             //then
+            then(lectureRepository.findByLectureId(lectureId))
             then(lectureRepository).should().save(any())
             assertEquals(expectedLecture, user)
         }


### PR DESCRIPTION
### 작업사항
- Lecture 조회 함수 추가 (비관적 락 적용된 케이스)
- 통합 테스트 작성 (비관적 락 정상 동작 확인)

### 리뷰 포인트
- yml에 hikari thread pool size를 변경하지 않고 50개의 thread로 테스트를 실행하는 경우 lock으로 인한 에러가 발생합니다. 다른 팀원분은 따로 Thread pool 설정을 해주지 않아도 정상적으로 처리되었는데, 어떤 문제가 있는지 확인 부탁드립니다.
- 테스트 해본 결과 비관적 락을 걸어도 먼저 진입한 Thread가 우선적으로 처리되지 않고있는 것을 확인했습니다(먼저 접근한 쓰레드라고 하더라도 Lock을 얻는 우선권이 없어보입니다). 추후 Queue를 공용으로 사용할 수 있는(ex. redis .... 등)곳에서 스케쥴 관리를 따로 해주어야 선입선출이 정상적으로 동작하는지 문의드립니다.